### PR TITLE
Omit command name in parameters when only one command is loaded

### DIFF
--- a/ManyConsole.Tests/ManyConsole.Tests.csproj
+++ b/ManyConsole.Tests/ManyConsole.Tests.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="can_have_default_command.cs" />
     <Compile Include="Can_have_required_parameters.cs" />
     <Compile Include="Can_verify_number_of_arguments_passed_to_command.cs" />
     <Compile Include="InlinedCommand.cs" />

--- a/ManyConsole.Tests/can_have_default_command.cs
+++ b/ManyConsole.Tests/can_have_default_command.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using NJasmine;
+
+namespace ManyConsole.Tests
+{
+    public class can_have_default_command : GivenWhenThenFixture
+    {
+        private const int Success = 999;
+
+        public class ExampleCommand : ConsoleCommand
+        {
+            public ExampleCommand()
+            {
+                this.IsCommand("Example");
+                this.HasOption("f|foo=", "This foo to use.", v => Foo = v);
+                this.SkipsCommandSummaryBeforeRunning();
+            }
+
+            public override int Run(string[] remainingArguments)
+            {
+                return Success;
+            }
+
+            public string Foo { get; set; }
+        }
+
+        public override void Specify()
+        {
+            given("exactly one command is loaded", () =>
+            {
+                var exampleCommand = new ExampleCommand();
+                var commands = new ConsoleCommand[] { exampleCommand };
+
+                when("no parameters are specified", () =>
+                {
+                    var output = new StringWriter();
+                    var exitCode = arrange(() => ConsoleCommandDispatcher.DispatchCommand(commands, new string[0], output));
+
+                    then("the output is empty", () =>
+                    {
+                        expect(() => string.IsNullOrEmpty(output.ToString().Trim()));
+                    });
+
+                    then("the exit code indicates the call succeeded", () =>
+                    {
+                        expect(() => exitCode == Success);
+                    });
+
+                    then("the command's property is not set", () =>
+                    {
+                        expect(() => exampleCommand.Foo == null);
+                    });
+                });
+
+                when("the only parameter specified is the command", () =>
+                {
+                    var output = new StringWriter();
+                    var exitCode = arrange(() => ConsoleCommandDispatcher.DispatchCommand(commands, new[] { "Example" }, output));
+
+                    then("the output is empty", () =>
+                    {
+                        expect(() => string.IsNullOrEmpty(output.ToString().Trim()));
+                    });
+
+                    then("the exit code indicates the call succeeded", () =>
+                    {
+                        expect(() => exitCode == Success);
+                    });
+
+                    then("the command's property is not set", () =>
+                    {
+                        expect(() => exampleCommand.Foo == null);
+                    });
+                });
+
+                when("the only parameter specified is not the command", () =>
+                {
+                    var output = new StringWriter();
+                    var exitCode = arrange(() => ConsoleCommandDispatcher.DispatchCommand(commands, new[] { "/f=bar" }, output));
+
+                    then("the output is empty", () =>
+                    {
+                        expect(() => string.IsNullOrEmpty(output.ToString().Trim()));
+                    });
+
+                    then("the exit code indicates the call succeeded", () =>
+                    {
+                        expect(() => exitCode == Success);
+                    });
+
+                    then("the command's property is set", () =>
+                    {
+                        expect(() => exampleCommand.Foo == "bar");
+                    });
+                });
+
+                when("both the command and an extra parameter are specified", () =>
+                {
+                    var output = new StringWriter();
+                    var exitCode = arrange(() => ConsoleCommandDispatcher.DispatchCommand(commands, new[] { "Example", "/f=bar" }, output));
+
+                    then("the output is empty", () =>
+                    {
+                        expect(() => string.IsNullOrEmpty(output.ToString().Trim()));
+                    });
+
+                    then("the exit code indicates the call succeeded", () =>
+                    {
+                        expect(() => exitCode == Success);
+                    });
+
+                    then("the command's property is set", () =>
+                    {
+                        expect(() => exampleCommand.Foo == "bar");
+                    });
+                });
+            });
+        }
+    }
+}

--- a/ManyConsole/ConsoleCommandDispatcher.cs
+++ b/ManyConsole/ConsoleCommandDispatcher.cs
@@ -16,30 +16,45 @@ namespace ManyConsole
 
             try
             {
-                if (arguments.Count() < 1)
-                    throw new ConsoleHelpAsException("No arguments specified.");
+                List<string> remainingArguments;
 
-                foreach(var possibleCommand in commands)
+                if (commands.Count() == 1)
                 {
-                    if (string.IsNullOrEmpty(possibleCommand.Command))
+                    selectedCommand = commands.First();
+
+                    CheckCommandProperty(selectedCommand);
+
+                    if (arguments.Count() > 0 && arguments.First().ToLower() == selectedCommand.Command.ToLower())
                     {
-                        throw new InvalidOperationException(String.Format(
-                            "Command {0} did not define property Command, which must specify its command text.",
-                            possibleCommand.GetType().Name));
+                        remainingArguments = selectedCommand.Options.Parse(arguments.Skip(1));
                     }
-
-                    if (arguments.First().ToLower() == possibleCommand.Command.ToLower())
+                    else
                     {
-                        selectedCommand = possibleCommand;
-
-                        break;
+                        remainingArguments = selectedCommand.Options.Parse(arguments);
                     }
                 }
+                else
+                {
+                    if (arguments.Count() < 1)
+                        throw new ConsoleHelpAsException("No arguments specified.");
 
-                if (selectedCommand == null)
-                    throw new ConsoleHelpAsException("Command name not recognized.");
+                    foreach (var possibleCommand in commands)
+                    {
+                        CheckCommandProperty(possibleCommand);
 
-                var remainingArguments = selectedCommand.Options.Parse(arguments.Skip(1));
+                        if (arguments.First().ToLower() == possibleCommand.Command.ToLower())
+                        {
+                            selectedCommand = possibleCommand;
+
+                            break;
+                        }
+                    }
+
+                    if (selectedCommand == null)
+                        throw new ConsoleHelpAsException("Command name not recognized.");
+
+                    remainingArguments = selectedCommand.Options.Parse(arguments.Skip(1));
+                }
 
                 CheckRequiredArguments(selectedCommand);
 
@@ -66,6 +81,16 @@ namespace ManyConsole
                 }
 
                 return -1;
+            }
+        }
+  
+        private static void CheckCommandProperty(ConsoleCommand command)
+        {
+            if (string.IsNullOrEmpty(command.Command))
+            {
+                throw new InvalidOperationException(String.Format(
+                    "Command {0} did not define property Command, which must specify its command text.",
+                    command.GetType().Name));
             }
         }
 


### PR DESCRIPTION
If only one command is loaded, allow the user to omit the command name in parameters. If multiple commands are loaded (or none at all), the existing behavior is unchanged.

For example, given an application named 'app' with a single command named 'example' that has an optional parameter 'foo', the user should be able to call it like this:

```
app
app --foo=bar
app example
app example --foo=bar
```
