### PR TITLE
Align and pad the command list using spaces

### DIFF
--- a/ManyConsole/Internal/ConsoleHelp.cs
+++ b/ManyConsole/Internal/ConsoleHelp.cs
@@ -14,10 +14,14 @@ namespace ManyConsole.Internal
         {
             console.WriteLine("Available commands are:");
             console.WriteLine();
-                    
-            foreach (var command in commands)
+
+            var commandList = commands.ToList();
+            var n = commandList.Max(c => c.Command.Length) + 1;
+            var commandFormatString = "    {0,-" + n + "}- {1}";
+
+            foreach (var command in commandList)
             {
-                console.WriteLine("    {0}\t- {1}", command.Command, command.OneLineDescription);
+                console.WriteLine(commandFormatString, command.Command, command.OneLineDescription);
             }
             console.WriteLine();
         }


### PR DESCRIPTION
I think this makes the output of the help command nicer-looking.
