### PR TITLE
Allow ILDASM

### DIFF
--- a/ManyConsole/Properties/AssemblyInfo.cs
+++ b/ManyConsole/Properties/AssemblyInfo.cs
@@ -3,18 +3,15 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-#if !SILVERLIGHT
-[assembly: SuppressIldasmAttribute()]
-#endif
-[assembly: CLSCompliantAttribute(false )]
-[assembly: ComVisibleAttribute(false)]
-[assembly: AssemblyTitleAttribute("ManyConsole 0.4.2.17")]
-[assembly: AssemblyDescriptionAttribute("A library for writing console applications.  Extends NDesk.Options to support separate commands from one console application.")]
-[assembly: AssemblyCompanyAttribute("n/a")]
-[assembly: AssemblyProductAttribute("ManyConsole 0.4.2.17")]
-[assembly: AssemblyCopyrightAttribute("Copyright © Frank Schwieterman 2011")]
-[assembly: AssemblyVersionAttribute("0.4.2.17")]
-[assembly: AssemblyInformationalVersionAttribute("0.4.2.17 / c15e683")]
-[assembly: AssemblyFileVersionAttribute("0.4.2.17")]
-[assembly: AssemblyDelaySignAttribute(false)]
+[assembly: CLSCompliant(false )]
+[assembly: ComVisible(false)]
+[assembly: AssemblyTitle("ManyConsole 0.4.2.17")]
+[assembly: AssemblyDescription("A library for writing console applications.  Extends NDesk.Options to support separate commands from one console application.")]
+[assembly: AssemblyCompany("n/a")]
+[assembly: AssemblyProduct("ManyConsole 0.4.2.17")]
+[assembly: AssemblyCopyright("Copyright © Frank Schwieterman 2011")]
+[assembly: AssemblyVersion("0.4.2.17")]
+[assembly: AssemblyInformationalVersion("0.4.2.17 / c15e683")]
+[assembly: AssemblyFileVersion("0.4.2.17")]
+[assembly: AssemblyDelaySign(false)]
 


### PR DESCRIPTION
Since not-signed builds are not supported, I am proposing a change that will allow at least to disassemble the code and sign it with ILDASM/ILASM.

Since the project is open source, the suppression of the ILDASM a weird choice anyway.