### PR TITLE
Add long description to command help

### DIFF
--- a/ManyConsole.Tests/lets_user_browse_command_help.cs
+++ b/ManyConsole.Tests/lets_user_browse_command_help.cs
@@ -63,6 +63,15 @@ namespace ManyConsole.Tests
             {
                 var commandC = new TestCommand()
                     .IsCommand("command-c", "one line description for C")
+                    .HasLongDescription(
+@"Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+sed do eiusmod tempor incididunt ut labore et dolore magna
+aliqua. Ut enim ad minim veniam, quis nostrud exercitation
+ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit
+esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.")
                     .HasAdditionalArguments(0, "<remaining> <args>")
                     .HasOption("o|option=", "option description", v => { });
 
@@ -76,6 +85,7 @@ namespace ManyConsole.Tests
                     Expect.That(output).ContainsInOrder(
                         commandC.Command,
                         commandC.OneLineDescription,
+                        commandC.LongDescription,
                         commandC.RemainingArgumentsHelpText,
                         "-o",
                         "--option",

--- a/ManyConsole/ConsoleCommand.cs
+++ b/ManyConsole/ConsoleCommand.cs
@@ -23,6 +23,7 @@ namespace ManyConsole
 
         public string Command { get; private set; }
         public string OneLineDescription { get; private set; }
+        public string LongDescription { get; private set; }
         public OptionSet Options { get; protected set; }
         public bool TraceCommandAfterParse { get; private set; }
         public int? RemainingArgumentsCount { get; private set; }
@@ -34,6 +35,12 @@ namespace ManyConsole
         {
             Command = command;
             OneLineDescription = oneLineDescription;
+            return this;
+        }
+
+        public ConsoleCommand HasLongDescription(string longDescription)
+        {
+            LongDescription = longDescription;
             return this;
         }
 

--- a/ManyConsole/Internal/ConsoleHelp.cs
+++ b/ManyConsole/Internal/ConsoleHelp.cs
@@ -38,6 +38,13 @@ namespace ManyConsole.Internal
             console.WriteLine();
             console.WriteLine("'" + selectedCommand.Command + "' - " + selectedCommand.OneLineDescription);
             console.WriteLine();
+
+            if (!string.IsNullOrEmpty(selectedCommand.LongDescription))
+            {
+                console.WriteLine(selectedCommand.LongDescription);
+                console.WriteLine();
+            }
+
             console.Write("Expected usage:");
 
             if (!skipExeInExpectedUsage)
@@ -70,6 +77,7 @@ namespace ManyConsole.Internal
             string[] skippedProperties = new []{
                 "Command",
                 "OneLineDescription",
+                "LongDescription",
                 "Options",
                 "TraceCommandAfterParse",
                 "RemainingArgumentsCount",


### PR DESCRIPTION
Allows a more detailed description of a particular command. Useful for describing usage, showing examples, etc.