### PR TITLE
Add ConsoleCommandDispatcher FindCommandsInAssembly() and FindCommandsInAllLoadedAssemblies() methods

### DIFF
--- a/ManyConsole/ConsoleCommandDispatcher.cs
+++ b/ManyConsole/ConsoleCommandDispatcher.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using ManyConsole.Internal;
 
 namespace ManyConsole
@@ -130,7 +131,21 @@ namespace ManyConsole
 
         public static IEnumerable<ConsoleCommand> FindCommandsInSameAssemblyAs(Type typeInSameAssembly)
         {
-            var assembly = typeInSameAssembly.Assembly;
+            if (typeInSameAssembly == null)
+                throw new ArgumentNullException("typeInSameAssembly");
+
+            return FindCommandsInAssembly(typeInSameAssembly.Assembly);
+        }
+
+        public static IEnumerable<ConsoleCommand> FindCommandsInAllLoadedAssemblies()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies().SelectMany(FindCommandsInAssembly);
+        }
+
+        public static IEnumerable<ConsoleCommand> FindCommandsInAssembly(Assembly assembly)
+        {
+            if (assembly == null)
+                throw new ArgumentNullException("assembly");
 
             var commandTypes = assembly.GetTypes()
                 .Where(t => t.IsSubclassOf(typeof(ConsoleCommand)))


### PR DESCRIPTION
FindCommandsInAllLoadedAssemblies() is useful when there many assemblies (potentially loaded using Reflection) that could contain commands. FindCommandsInAssembly() allows specifying an assembly directly when you have one (e.g. loaded using Assembly.Load) rather than having to hack around it by finding a type in that assembly.