### PR TITLE
Add syntax highlighting to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ To use ManyConsole:
 
 Run this from NuGet Package Management Console:
 
-```
+```posh
 Install-Package ManyConsole
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ Install-Package ManyConsole
 
 Drop this in to automatically load all of the commands that we'll create next:
 
-```
+```csharp
 public class Program
 {
     public static int Main(string[] args)
@@ -49,7 +49,7 @@ public class Program
 
 Create a command with one optional, one required and a short and long description:
 
-```
+```csharp
 public class PrintFileCommand : ConsoleCommand
 {
     private const int Success = 0;
@@ -139,7 +139,7 @@ Hello world!
 
 Now you can easily supply multiple commands with their own set of unique arguments:
 
-```
+```csharp
 public class EchoCommand : ConsoleCommand
 {
     public string ToEcho { get; set; }


### PR DESCRIPTION
Just a little cleanup of the `readme` to improve readability.

I did try adding `batch` highlighting to the command examples, but it did not look that good.