### PR TITLE
Added ConsoleOut property to ConsoleCommand and assign the value when…

### DIFF
--- a/ManyConsole/ConsoleCommand.cs
+++ b/ManyConsole/ConsoleCommand.cs
@@ -19,6 +19,7 @@ namespace ManyConsole
             RemainingArgumentsHelpText = "";
             OptionsHasd = new OptionSet();
             RequiredOptions = new List<RequiredOptionRecord>();
+	        ConsoleOut = Console.Out;
         }
 
         public string Command { get; private set; }
@@ -30,6 +31,7 @@ namespace ManyConsole
         public string RemainingArgumentsHelpText { get; private set; }
         private OptionSet OptionsHasd { get; set; }
         private List<RequiredOptionRecord> RequiredOptions { get; set; }
+        public TextWriter ConsoleOut { get; set; }
 
         public ConsoleCommand IsCommand(string command, string oneLineDescription = "")
         {

--- a/ManyConsole/ConsoleCommandDispatcher.cs
+++ b/ManyConsole/ConsoleCommandDispatcher.cs
@@ -21,9 +21,9 @@ namespace ManyConsole
 
             TextWriter console = consoleOut;
 
-            foreach (var command in commands)
-            {
-                ValidateConsoleCommand(command);
+            foreach (var command in commands) {
+	            command.ConsoleOut = consoleOut;
+				ValidateConsoleCommand(command);
             }
 
             try


### PR DESCRIPTION
I liked what you did where you pass the TextWriter to the ConsoleCommandDispatcher.DispatchCommand() method, however it was not propagated to the command itself.  I added a ConsoleOut property to the ConsoleCommand class that can be used in the commands to make sure it writes to the same TextWriter that the dispatcher writes to.

For me, this made testing easier because I would have had to come up with my own mechanism for having my commands write to a testing TextWriter rather than Console.Out.

P.S. - This is my first pull request.  Hope I did this correctly :)