### PR TITLE
Treat properties the same as fields in ShowParsedCommand

### DIFF
--- a/ManyConsole/Internal/ConsoleHelp.cs
+++ b/ManyConsole/Internal/ConsoleHelp.cs
@@ -105,8 +105,7 @@ namespace ManyConsole.Internal
 
             foreach (var property in properties)
             {
-                object value = property.GetValue(consoleCommand, new object[0]);
-                allValuesToTrace[property.Name] = value != null ? value.ToString() : "null";
+                allValuesToTrace[property.Name] = MakeObjectReadable(property.GetValue(consoleCommand, new object[0]));
             }
 
             foreach (var field in fields)


### PR DESCRIPTION
If you use public properties instead of fields for your command properties, the values aren't sent through MakeObjectReadable. This means enumerable values aren't visible like they are for fields.