### PR TITLE
Remove AssemblyInfo.cs from SampleConsole.csproj

### DIFF
--- a/SampleConsole/SampleConsole.csproj
+++ b/SampleConsole/SampleConsole.csproj
@@ -61,7 +61,6 @@
     <Compile Include="GetTimeCommand.cs" />
     <Compile Include="MattsCommand.cs" />
     <Compile Include="Program.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleConsoleModeCommand.cs" />
     <Compile Include="StatefulConsoleModeCommand.cs" />
     <Compile Include="ThrowException.cs" />


### PR DESCRIPTION
Commit 30f6159 removed AssemblyInfo.cs files, but kept the reference in SampleConsole.csproj.

This results in a build error after a clean git clone. So this PR removes such reference.